### PR TITLE
docs(quickguide): change quickguide to use oci based helm repo

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -72,7 +72,6 @@ By following this quickstarter guide line by line, you will obtain an running in
 * Clone the following repositories:
     ```powershell
     git clone https://github.com/telekom/pubsub-horizon.git
-    git clone https://github.com/telekom/pubsub-horizon-helm-charts.git
     git clone https://github.com/telekom/pubsub-horizon-starlight.git --branch 4.0.1
     git clone https://github.com/telekom/pubsub-horizon-galaxy.git --branch 4.0.2
     git clone https://github.com/telekom/pubsub-horizon-comet.git --branch 4.0.1
@@ -429,7 +428,7 @@ If you have not yet installed an identity provider in the cluster, you can do so
 
 2. Install Horizon
     ```powershell
-    helm upgrade -i -n platform -f .\horizon-nonprod.yaml horizon .\pubsub-horizon-helm-charts\horizon-all
+    helm upgrade -i -n platform -f .\horizon-nonprod.yaml horizon oci://ghcr.io/telekom/o28m-charts/horizon-all --version 1.0.0-ci-semantic-release
     ```
 
 ## Try it out

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -428,7 +428,7 @@ If you have not yet installed an identity provider in the cluster, you can do so
 
 2. Install Horizon
     ```powershell
-    helm upgrade -i -n platform -f .\horizon-nonprod.yaml horizon oci://ghcr.io/telekom/o28m-charts/horizon-all --version 1.0.0-ci-semantic-release
+    helm upgrade -i -n platform -f .\horizon-nonprod.yaml horizon oci://ghcr.io/telekom/o28m-charts/horizon-all --version 1.0.0
     ```
 
 ## Try it out


### PR DESCRIPTION
Since we will enabled oci based hosting of helm packages on github, we need to update the quickguide accordingly.